### PR TITLE
README作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,102 @@
 # Tsundoku
 
 ## サービス名
+
 Tsundoku
 ※積読とは違い、読んでいった本を積むことをTsundokuと定義しています。
 
+## サービスURL
+
+https://tsundoku.tech
+
 ## サービス概要
+
 1. 読む本を登録
-2. その本の章ごとに読書メモを取る
+2. 章ごとに読書メモを取る
 3. メモをとった日は、自動的にログがつけられます。
-   読んできた本の一覧表示と、GitHubのContributionグラフのような視覚的な読書ログを確認することができ、外部に読書習慣をアピールすることができます！
+   読んだ本の一覧表示や、GitHubのContributionグラフのように視覚的に読書習慣を確認できます。また、読書ログを外部に公開してアピールすることが可能です！
+
+
+## 使い方
+|  本を検索  |  読書メモを取る  |  読書ログを公開  |
+|  ------- | -------------  | -------------  |
+|  本を検索して、登録することができます。  |  本ごとにメモを取ることができます。  |  読書した本やログは公開することができます。  |
+|  [![Image from Gyazo](https://i.gyazo.com/40784b5839854e435a8fd362ceb45d2a.gif)](https://gyazo.com/40784b5839854e435a8fd362ceb45d2a)  | [![Image from Gyazo](https://i.gyazo.com/b3f97f2a78c4eb50d6968f5d855b52c2.gif)](https://gyazo.com/b3f97f2a78c4eb50d6968f5d855b52c2)  | [![Image from Gyazo](https://i.gyazo.com/4729da63da9649d1a6c027a7a690c81c.jpg)](https://gyazo.com/4729da63da9649d1a6c027a7a690c81c) |
+
+
+## 使用技術
+### フロントエンド
+<img src='https://img.shields.io/badge/Next.js-696969.svg?logo=nextdotjs'>
+<img src='https://img.shields.io/badge/React-696969.svg?logo=react'>
+<img src='https://img.shields.io/badge/Typescript-696969.svg?logo=typescript'>
+<img src='https://img.shields.io/badge/Storybook-696969.svg?logo=storybook'>
+<img src='https://img.shields.io/badge/Mantine-696969.svg?logo=mantine'>
+<img src='https://img.shields.io/badge/Auth.js-696969.svg?logo='>  
+
+- Next.js 14.2.3
+- React 18
+- Typescript 5
+- Storybook 8.1.9
+- Mantine 7.11.0
+- Auth.js 5.0.0
+
+### バックエンド
+<img src='https://img.shields.io/badge/Ruby on Rails-696969.svg?logo=rubyonrails'>
+<img src='https://img.shields.io/badge/Ruby-3.3.1-696969.svg?logo=ruby'>
+<img src='https://img.shields.io/badge/Rubocop-1.64.0-696969.svg?logo=rubocop'>
+<img src='https://img.shields.io/badge/Rspec-3.13.0-696969.svg?logo=rspec'>
+<img src='https://img.shields.io/badge/Postgresql-1.5.6-696969.svg?logo=postgresql'>
+<img src='https://img.shields.io/badge/Factorybot-6.4.6-696969.svg?logo='>
+<img src='https://img.shields.io/badge/Simplecov-0.22.0-696969.svg?logo='>
+
+- Rails7.1.3.3 
+- Ruby 3.3.1
+- Rubocop 1.64.0
+- Rspec 3.13.0
+- Postgresql 1.5.6
+- Factorybot 6.4.6
+- Simplecov 0.22.0
+
+## 起動方法
+今回[Auth.js](https://authjs.dev/)を用いて、認証機能を実装しています。
+Tsundokuでは、Googleログインを採用しているため起動前に以下の設定をする必要があります。
+[Google OAuthの設定](https://github.com/reckyy/tsundoku/wiki/Google-OAuth%E3%81%AE%E8%A8%AD%E5%AE%9A)
+
+
+### 環境変数の登録
+
+`.env.local`を作成し、以下の内容を追加してください。
+`AUTH_SECRET`は、`npx auth secret`で生成された値を入力してください。
+```
+AUTH_GOOGLE_ID={CLIENT_ID}
+AUTH_GOOGLE_SECRET={CLIENT_SECRET}
+AUTH_SECRET={YOUR_SECRET}
+NEXT_PUBLIC_RAILS_API_URL="http://localhost:3001/api"
+NEXT_PUBLIC_NEXT_URL="http://localhost:3000"
+STORYBOOK_NEXT_PUBLIC_RAILS_API_URL="http://localhost:3001/api"
+STORYBOOK_NEXT_PUBLIC_NEXT_URL="http://localhost:3000"
+```
+
+### セットアップ
+`bin/setup`
+
+### 起動
+`bin/dev`
+
+## テスト
+### バックエンドのテスト
+```ruby
+cd tsundoku-backend
+rspec
+rubocop
+```
+
+### フロントエンドのテスト
+```typescript
+cd tsundoku-frontend
+npm run storybook
+// 上記を実行したターミナルは開いたまま別のターミナルで下のコードを実行
+npm run test-storybook
+// 実行結果をブラウザで見たい場合は
+open coverage/storybook/lcov-report/index.html
+```

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,11 @@
+set -e
+
+echo "Starting backend server..."
+cd tsundoku-backend
+bin/rails s &
+
+echo "Starting frontend server..."
+cd ../tsundoku-frontend
+npm run dev &
+
+wait

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,17 @@
+set -e
+
+echo 'Setting up the backend...'
+cd tsundoku-backend
+bundle install
+
+echo 'Prepare DB...'
+bin/rails db:prepare
+
+cd ..
+
+echo 'Setting up the frontend...'
+cd tsundoku-frontend
+npm install
+
+echo 'Setup complete.'
+cd ..


### PR DESCRIPTION
## Issue
- https://github.com/reckyy/tsundoku/issues/117

## description
親リポジトリのREADMEを作成した。サービスURL・使い方・使用技術・起動方法（環境変数の登録／セットアップ／起動）・バックエンドとフロントエンドそれぞれのテストの実行方法を記載している。

あわせて`bin/setup`と`bin/dev`を追加した。`bin/setup`はバックエンドの`bundle install`と`db:prepare`、フロントエンドの`npm install`をまとめて実行し、`bin/dev`は`bin/rails s`と`npm run dev`を並行で起動する。
